### PR TITLE
Added a link to print.md in the menu

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ pages:
     - AFS: 'afs.md'
     - 'map.md'
     - 'news.md'
+    - 'print.md'
   - Accounts:
     - Cri and Bocal accounts: 'accounts.md'
     - Recover and modify passwords: 'passwords.md'


### PR DESCRIPTION
Forgot to add the link to `print.md` in the menu.